### PR TITLE
Add env vars back

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,7 +4,7 @@ ADGUARD_PORT=<adguard-server-port>
 
 # Cloudflare / Domain
 CLOUDFLARE_EMAIL=<my-cloudflare@email.com>
-CF_API_KEY=<my-cloudflare-api-key>
+CLOUDFLARE_API_KEY=<my-cloudflare-api-key>
 DOMAIN_NAME=<my-domain.com>
 
 # Docker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -37,7 +37,11 @@ services:
   plex:
     container_name: plex
     environment:
+      - ADVERTISE_IP=${ADVERTISE_IP}
       - HOSTNAME="Plex"
+      - PLEX_CLAIM=${PLEX_CLAIM}
+      - PGID=${PLEX_GID}
+      - PUID=${PLEX_UID}
     image: plexinc/pms-docker:1.25.4.5487-648a8f9f9
     labels:
       - traefik.enable=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,12 @@ services:
       - --providers.file.directory=/etc/traefik/rules
       - --providers.file.watch=true # watch top-level rules/ dir for file changes
     container_name: traefik
+    environment:
+      - ADGUARD_IP=${ADGUARD_IP}
+      - ADGUARD_PORT=${ADGUARD_PORT}
+      - CF_API_KEY=${CLOUDFLARE_API_KEY}
+      - CLOUDFLARE_EMAIL=${CLOUDFLARE_EMAIL}
+      - DOMAIN_NAME=${DOMAIN_NAME}
     image: traefik:v2.6.0
     labels:
       - traefik.enable=true


### PR DESCRIPTION
After changing ISPs and the server hardware crapping out, I needed to spin everything back up from scratch.  Removing the env vars from the docker-compose files borked plex and traefik, so adding back until I can correctly clean this up.